### PR TITLE
Conflict files not named "emacs-snapshot"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -438,6 +438,14 @@ override_dh_auto_install: $(autogen_install_files)
 	  cd $(pkgdir_common)/usr/share/emacs/$(runtime_ver)/etc/images/icons \
 	    && convert hicolor/32x32/apps/emacs.{png,xpm}
 
+	  # Remove emacs23 icon versions
+	  cd $(pkgdir_common)/usr/share/emacs/$(runtime_ver)/etc/images/icons \
+	    && rm hicolor/*/apps/emacs23.*
+	  cd $(pkgdir_common)/usr/share/emacs/$(runtime_ver)/etc/images/icons \
+	    && rm hicolor/*/mimetypes/emacs-document23.svg
+	  cd $(pkgdir_common)/usr/share/icons/hicolor/scalable/mimetypes \
+	    && rm emacs-document23.svg
+
 	  # Fixup image files in unversioned directories (version
 	  # unversioned images) and prepare for update-alternatives.
 	  cd $(pkgdir_common)/usr/share/icons/hicolor \

--- a/debian/rules
+++ b/debian/rules
@@ -410,6 +410,9 @@ override_dh_auto_install: $(autogen_install_files)
 	  rm -r $(pkgdir_common)/usr/bin
 	  rm -r $(pkgdir_common)/usr/lib
 
+	  cd $(pkgdir_common)/usr/share/appdata \
+	    && mv emacs.appdata.xml $(flavor).appdata.xml
+
 	cd $(pkgdir_common)/usr/share/emacs/$(runtime_ver)/etc \
 	  && test -f DOC
 	cd $(pkgdir_common)/usr/share/emacs/$(runtime_ver)/etc \


### PR DESCRIPTION
The following files in the emacs-snapshot-common package are not
named with the flavor "emacs-snapshot".

  - /usr/share/appdata/emacs.appdata.xml
  - /usr/share/icons/hicolor/scalable/mimetypes/emacs-document23.svg

Currently emacs.appdata.xml conflicts with the emacs-common package
in Debian experimental.  Please avoid the conflicts.

cf.
  - https://salsa.debian.org/rlb/deb-emacs/commit/4cac7d3123874d4941f174518ba954801ae9a8e5
  - https://salsa.debian.org/rlb/deb-emacs/commit/fe48bc284845397551ac9ae7b75e3d43c427d15f
  - https://packages.qa.debian.org/e/emacs.html

P.S. The file /usr/lib/systemd/user/emacs.service in the
emacs-snapshot-bin-common package would also be problematic in future.
