### PR TITLE
Don't install /usr/include by the -common package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -411,6 +411,7 @@ override_dh_auto_install: $(autogen_install_files)
 	  cp -a $(install_dir_x)/* $(pkgdir_common)
 
 	  rm -r $(pkgdir_common)/usr/bin
+	  rm -r $(pkgdir_common)/usr/include
 	  rm -r $(pkgdir_common)/usr/lib
 
 	  cd $(pkgdir_common)/usr/share/metainfo \


### PR DESCRIPTION
emacs-snapshot-common fails to install on Debian sid, because
/usr/include/emacs-module.h in emacs-snapshot-common conflicts with
emacs-common 1:26.3+1-1.

This patch prevents this problem.
