### PR TITLE
Use flavor for emacs.service

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,8 @@ Section: editors
 Priority: optional
 Maintainer: Rob Browning <rlb@defaultvalue.org>
 Build-Depends: bsd-mailx | mailx, libncurses5-dev, texinfo, liblockfile-dev, librsvg2-dev,
- libgif-dev | libungif4-dev, libtiff-dev | libtiff-dev, xaw3dg-dev,
+ libgif-dev | libungif4-dev, libtiff-dev | libtiff-dev,
+ libsystemd-dev, xaw3dg-dev,
  libpng-dev, libjpeg-dev, libm17n-dev, libotf-dev,
  libgpm-dev [linux-any], libdbus-1-dev,
  autoconf, automake, autotools-dev, dpkg-dev (>> 1.10.0), quilt (>= 0.42),

--- a/debian/rules
+++ b/debian/rules
@@ -530,6 +530,11 @@ override_dh_auto_install: $(autogen_install_files)
 	  # The .pdmp is flavor-specific, so I don't install it here
 	  rm $(pkgdir_bin_common)/usr/lib/emacs/$(runtime_ver)/$(target)/emacs.pdmp
 
+	  # The systemd service
+	  cd $(pkgdir_bin_common)/usr/lib/systemd/user \
+	    && mv emacs.service $(flavor).service \
+	    && perl -pwi -e 's|/emacs |/$(flavor) |g' $(flavor).service
+
 	  # Make sure there's just one.
 	  test -f $(pkgdir_bin_common)/usr/bin/emacs-*
 	  rm $(pkgdir_bin_common)/usr/bin/{emacs,emacs-*}


### PR DESCRIPTION
The systemd unit file emacs.service should be renamed, because it
conflicts with Debian's emacs-bin-common, as mentioned in
<https://github.com/dkogan/emacs-snapshot/pull/1#issuecomment-449548020>.

Also, debian/control.in should be updated, because debian/control
is generated from debian/control.in.
