### PR TITLE
Install emacs-module.h as $(flavor)-module.h

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -414,9 +414,10 @@ override_dh_auto_install: $(autogen_install_files)
 	  cp -a $(install_dir_x)/* $(pkgdir_common)
 
 	  rm -r $(pkgdir_common)/usr/bin
-	  rm -r $(pkgdir_common)/usr/include
 	  rm -r $(pkgdir_common)/usr/lib
 
+	  cd $(pkgdir_common)/usr/include \
+	    && mv emacs-module.h $(flavor)-module.h
 	  cd $(pkgdir_common)/usr/share/metainfo \
 	    && mv emacs.appdata.xml $(flavor).appdata.xml
 


### PR DESCRIPTION
Instead of removing /usr/include, install renamed file to avoid
conflicts and develop dynamic modules for Emacs 28.
cf. https://github.com/dkogan/emacs-snapshot/pull/2
