### PR TITLE
Set NATIVE_FULL_AOT to native compile ahead-of-time

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -126,6 +126,10 @@ ifeq (,$(joblimit))
   joblimit := 1
 endif
 
+ifeq ($(NO_NATIVE_COMP),)
+  export NATIVE_FULL_AOT := 1
+endif
+
 target := $(DEB_HOST_GNU_TYPE)
 movemail_bin := usr/lib/emacs/$(runtime_ver)/$(target)/movemail
 


### PR DESCRIPTION
This patch enables ahead-of-time native compilation to reduce
user's burden due to deferred compilation, though this will
increase build time and size of packages.
