### PR TITLE
Don't install desktop files in -common to avoid conflicts

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -480,6 +480,9 @@ override_dh_auto_install: $(autogen_install_files)
 	  rm $(pkgdir_common)/usr/share/emacs/$(runtime_ver)/etc/emacs.desktop
 	  rm $(pkgdir_common)/usr/share/applications/emacs.desktop
 
+	  # Remove desktop files possibly conflicted with emacs-common.
+	  rm -f $(pkgdir_common)/usr/share/applications/*.desktop
+
 	  # Mangle info files.
 	  chmod 755 debian/mangle-info
 	  for f in $(main_dir_info_files); \


### PR DESCRIPTION
I've noticed that the following desktop files in emacs-snapshot-common
will conflict with Debian's emacs-common 28.1, so just removed.

  - /usr/share/applications/emacs-mail.desktop
  - /usr/share/applications/emacsclient-mail.desktop
  - /usr/share/applications/emacsclient.desktop

(Actually, my unofficial emacs28 package failed because of this issue.
 cf. https://github.com/tats/emacs-snapshot/tree/deb-emacs28)
