### PR TITLE
Switch to libgccjit-11-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: bsd-mailx | mailx, libncurses5-dev, texinfo, liblockfile-dev, lib
  libgnutls28-dev, libxml2-dev, libselinux1-dev [linux-any], libmagick++-dev,
  libgconf2-dev, libasound2-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
  libacl1-dev,
- libgccjit-10-dev,
+ libgccjit-11-dev,
  libjansson-dev,
  zlib1g-dev
 Homepage: http://www.gnu.org/software/emacs/

--- a/debian/control.in
+++ b/debian/control.in
@@ -12,7 +12,7 @@ Build-Depends: bsd-mailx | mailx, libncurses5-dev, texinfo, liblockfile-dev, lib
  libgnutls28-dev, libxml2-dev, libselinux1-dev [linux-any], libmagick++-dev,
  libgconf2-dev, libasound2-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
  libacl1-dev,
- libgccjit-10-dev,
+ libgccjit-11-dev,
  libjansson-dev,
  zlib1g-dev
 Homepage: http://www.gnu.org/software/emacs/


### PR DESCRIPTION
GCC 11 is now default in Debian sid.

cf. https://packages.debian.org/unstable/gcc
    https://tracker.debian.org/pkg/gcc-defaults
    https://tracker.debian.org/pkg/gcc-11
    https://tracker.debian.org/pkg/gcc-10
