### PR TITLE
Depend on libgcjit10 or libgcjit11.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: bsd-mailx | mailx, libncurses5-dev, texinfo, liblockfile-dev, lib
  libgnutls28-dev, libxml2-dev, libselinux1-dev [linux-any], libmagick++-dev,
  libgconf2-dev, libasound2-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
  libacl1-dev,
- libgccjit-11-dev,
+ libgccjit-10-dev | libgccjit-11-dev,
  libjansson-dev,
  zlib1g-dev
 Homepage: http://www.gnu.org/software/emacs/


### PR DESCRIPTION
This lets it build cleanly on bullseye.