### PR TITLE
Avoid patch rejection when INFO_COMMON is modified

### DIFF
--- a/debian/patches/0003-Remove-files-that-appear-to-be-incompatible-with-the.patch
+++ b/debian/patches/0003-Remove-files-that-appear-to-be-incompatible-with-the.patch
@@ -156,7 +156,7 @@ index 1831bbb..c7a6da5 100644
  
 +# Debian: moved DFSG incompatible files to emacs*-common-non-dfsg
 +# package (see /usr/share/doc/emacs*-common/copyright).
-+INFO_COMMON = efaq
++INFO_COMMON = efaq transient
 +INFO_INSTALL = $(INFO_COMMON)
 +INFO_TARGETS = $(INFO_COMMON)
 +

--- a/debian/patches/0003-Remove-files-that-appear-to-be-incompatible-with-the.patch
+++ b/debian/patches/0003-Remove-files-that-appear-to-be-incompatible-with-the.patch
@@ -150,29 +150,19 @@ diff --git a/doc/misc/Makefile.in b/doc/misc/Makefile.in
 index 1831bbb..c7a6da5 100644
 --- a/doc/misc/Makefile.in
 +++ b/doc/misc/Makefile.in
-@@ -63,18 +63,14 @@ INSTALL_DATA = @INSTALL_DATA@
- MAKEINFO = @MAKEINFO@
- MAKEINFO_OPTS = --force -I$(emacsdir)
+@@ -84,6 +84,12 @@ INFO_INSTALL = $(INFO_COMMON) $(DOCMISC_W32)
+ ## because the info files are pre-built in release tarfiles.
+ INFO_TARGETS = $(INFO_COMMON) efaq-w32
  
 +# Debian: moved DFSG incompatible files to emacs*-common-non-dfsg
 +# package (see /usr/share/doc/emacs*-common/copyright).
-+
- ## On MS Windows, efaq-w32; otherwise blank.
- DOCMISC_W32 = @DOCMISC_W32@
- 
- ## Info files to build and install on all platforms.
--INFO_COMMON = auth autotype bovine calc ccmode cl dbus dired-x		\
--	ebrowse ede ediff edt efaq eglot eieio emacs-gnutls		\
--	emacs-mime epa erc ert eshell eudc eww flymake forms gnus	\
--	htmlfontify idlwave ido info.info mairix-el message mh-e	\
--	modus-themes newsticker nxml-mode octave-mode org pcl-cvs pgg	\
--	rcirc reftex remember sasl sc semantic ses sieve smtpmail	\
--	speedbar srecode todo-mode tramp transient url use-package	\
--	vhdl-mode vip viper vtable widget wisent woman
 +INFO_COMMON = efaq
- 
- ## Info files to install on current platform.
- INFO_INSTALL = $(INFO_COMMON) $(DOCMISC_W32)
++INFO_INSTALL = $(INFO_COMMON)
++INFO_TARGETS = $(INFO_COMMON)
++
+ ## Some manuals have their source in .org format.
+ ## This is discouraged because the .texi files it generates
+ ## are not as well formatted as handwritten ones.
 diff --git a/lisp/help.el b/lisp/help.el
 index 83be85b..a847e35 100644
 --- a/lisp/help.el

--- a/debian/rules
+++ b/debian/rules
@@ -134,7 +134,7 @@ target := $(DEB_HOST_GNU_TYPE)
 movemail_bin := usr/lib/emacs/$(runtime_ver)/$(target)/movemail
 
 # Info files that are going to show up in the main dir.
-main_dir_info_files := efaq.info
+main_dir_info_files := efaq.info transient.info
 
 # Files that the build stage depends on (may also be listed in other vars).
 persistent_autogen_build_files := debian/control debian/copyright


### PR DESCRIPTION
Sometimes applying the patch 0003-Remove-files-that-appear-to-be-incompatible-with-the.patch
fails, because the patch depends on the value of INFO_COMMON.

This pull request removes the part of the value of INFO_COMMON to
avoid the rejection.  Also, transient.info is added according to
Debian's emacs-common.
