### PR TITLE
Mention the Savannah site instead of the FTP sites in debian/copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,14 +3,9 @@
 This package was debianized by Rob Browning <rlb@defaultvalue.org> on
 Tue, 16 Dec 1997 00:05:45 -0600.
 
-The original source archive is emacs-29.0.50.tar.gz, and it
-can be found here for stable releases:
+The original source for this package can be found at:
 
-  ftp://ftp.gnu.org:/gnu/emacs/
-
-and here for alpha pre-releases:
-
-  ftp://alpha.gnu.org:/gnu/emacs/pretest/
+  https://savannah.gnu.org/projects/emacs
 
 Please see /usr/share/doc/emacs-snapshot-common/README.Debian.gz for a
 description of the Debian specific differences from the upstream

--- a/debian/copyright.in
+++ b/debian/copyright.in
@@ -3,14 +3,9 @@
 This package was debianized by Rob Browning <rlb@defaultvalue.org> on
 Tue, 16 Dec 1997 00:05:45 -0600.
 
-The original source archive is emacs-@UPSTREAM_VERSION@.tar.gz, and it
-can be found here for stable releases:
+The original source for this package can be found at:
 
-  ftp://ftp.gnu.org:/gnu/emacs/
-
-and here for alpha pre-releases:
-
-  ftp://alpha.gnu.org:/gnu/emacs/pretest/
+  https://savannah.gnu.org/projects/emacs
 
 Please see /usr/share/doc/@DEB_FLAVOR@-common/README.Debian.gz for a
 description of the Debian specific differences from the upstream


### PR DESCRIPTION
This removes @UPSTREAM_VERSION@ to reduce modifications.
cf. https://github.com/dkogan/emacs-snapshot/commit/1fdc8cc302efb6b5836ab917602ed7bb9c5c6537
    https://github.com/dkogan/emacs-snapshot/commit/2057065ab75f197f9eb18bdb5c4e6069e8c15eb2
