### PR TITLE
Build emacs with tree-sitter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends: bsd-mailx | mailx, libncurses5-dev, texinfo, liblockfile-dev, lib
  libgnutls28-dev, libxml2-dev, libselinux1-dev [linux-any], libmagick++-dev,
  libgconf2-dev, libasound2-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
  libacl1-dev,
+ libtree-sitter-dev,
  libgccjit-12-dev | libgccjit-11-dev | libgccjit-10-dev,
  libjansson-dev,
  zlib1g-dev

--- a/debian/rules
+++ b/debian/rules
@@ -325,6 +325,7 @@ ifeq ($(NO_NATIVE_COMP),)
 confflags += --with-native-compilation
 endif
 confflags += --with-pop=yes
+confflags += --with-tree-sitter
 confflags += --enable-locallisppath=$(local_lpath)
 
 # x configure flags


### PR DESCRIPTION
This pull request configures Emacs to use the newly added native Tree Sitter implementation.

It passes "--with-tree-sitter" to ./configure and adds `libtree-sitter` to the depends.