### PR TITLE
Add -pgtk package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,8 +25,8 @@ Depends: emacs-snapshot-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${m
 Provides: emacs-snapshot, emacsen, editor, info-browser, mail-reader, news-reader
 Suggests: emacs-snapshot-common-non-dfsg
 Conflicts: emacs-snapshot-no-native-comp-lucid,
-  emacs-snapshot, emacs-snapshot-nox, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
-Replaces: emacs-snapshot, emacs-snapshot-nox
+  emacs-snapshot, emacs-snapshot-pgtk, emacs-snapshot-nox, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: emacs-snapshot, emacs-snapshot-pgtk, emacs-snapshot-nox
 Description: GNU Emacs editor (with Lucid GUI support)
  GNU Emacs is the extensible self-documenting text editor.  This
  package contains a version of Emacs with support for a graphical user
@@ -38,14 +38,29 @@ Description: GNU Emacs editor (with Lucid GUI support)
  https://bugzilla.gnome.org/show_bug.cgi?id=85715 for more
  information.
 
+Package: emacs-snapshot-pgtk
+Architecture: any
+Depends: emacs-snapshot-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Provides: emacs-snapshot, emacsen, editor, info-browser, mail-reader, news-reader
+Suggests: emacs-snapshot-common-non-dfsg
+Conflicts: emacs-snapshot-no-native-comp-pgtk,
+  emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-nox, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-nox
+Description: GNU Emacs editor (with pure GTK GUI support)
+ GNU Emacs is the extensible self-documenting text editor.  This
+ package contains a version of Emacs with support for a graphical user
+ interface based on pure GTK.  We recommend that you use this only if
+ you are running a window system other than X that's supported by GDK,
+ such as Wayland and Broadway.
+
 Package: emacs-snapshot-nox
 Architecture: any
 Depends: emacs-snapshot-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides: emacs-snapshot, editor, emacsen, info-browser, mail-reader, news-reader
 Suggests: emacs-snapshot-common-non-dfsg
 Conflicts: emacs-snapshot-no-native-comp-nox,
-  emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
-Replaces: emacs-snapshot, emacs-snapshot-lucid
+  emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-pgtk, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-pgtk
 Description: GNU Emacs editor (without GUI support)
  GNU Emacs is the extensible self-documenting text editor.  This
  package contains a version of Emacs compiled without support for X,
@@ -57,8 +72,8 @@ Depends: emacs-snapshot-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${m
 Provides: editor, emacsen, info-browser, mail-reader, news-reader
 Suggests: emacs-snapshot-common-non-dfsg
 Conflicts: emacs-snapshot-no-native-comp,
-  emacs-snapshot-lucid, emacs-snapshot-nox, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
-Replaces: emacs-snapshot-lucid, emacs-snapshot-nox
+  emacs-snapshot-lucid, emacs-snapshot-pgtk, emacs-snapshot-nox, emacs-snapshot-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: emacs-snapshot-lucid, emacs-snapshot-pgtk, emacs-snapshot-nox
 Description: GNU Emacs editor (with GTK+ GUI support)
  GNU Emacs is the extensible self-documenting text editor.  This
  package contains a version of Emacs with a graphical user interface
@@ -72,7 +87,7 @@ Depends: emacs-snapshot-common (= ${source:Version}), ${shlibs:Depends}, ${misc:
 Description: GNU Emacs editor's shared, architecture dependent files
  GNU Emacs is the extensible self-documenting text editor.
  This package contains the architecture dependent infrastructure
- that's shared by emacs-snapshot, emacs-snapshot-lucid, and emacs-snapshot-nox.
+ that's shared by emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-pgtk, and emacs-snapshot-nox.
 
 # This depends on the emacs-el package. It is needed only for the native-comp
 # packages so tha they have something to compile. I leave the Depends even for
@@ -87,7 +102,7 @@ Conflicts: emacs-snapshot-no-native-comp-common,
 Description: GNU Emacs editor's shared, architecture independent infrastructure
  GNU Emacs is the extensible self-documenting text editor.
  This package contains the architecture independent infrastructure
- that's shared by emacs-snapshot, emacs-snapshot-lucid, and emacs-snapshot-nox.
+ that's shared by emacs-snapshot, emacs-snapshot-lucid, emacs-snapshot-pgtk, and emacs-snapshot-nox.
 
 Package: emacs-snapshot-el
 Conflicts: emacs-snapshot-no-native-comp-el

--- a/debian/control.in
+++ b/debian/control.in
@@ -25,8 +25,8 @@ Depends: @DEB_FLAVOR@-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${mis
 Provides: @DEB_FLAVOR@, emacsen, editor, info-browser, mail-reader, news-reader
 Suggests: @DEB_FLAVOR@-common-non-dfsg
 Conflicts: @DEB_FLAVOR_OTHER_NATIVE_COMP@-lucid,
-  @DEB_FLAVOR@, @DEB_FLAVOR@-nox, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
-Replaces: @DEB_FLAVOR@, @DEB_FLAVOR@-nox
+  @DEB_FLAVOR@, @DEB_FLAVOR@-pgtk, @DEB_FLAVOR@-nox, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: @DEB_FLAVOR@, @DEB_FLAVOR@-pgtk, @DEB_FLAVOR@-nox
 Description: GNU Emacs editor (with Lucid GUI support)
  GNU Emacs is the extensible self-documenting text editor.  This
  package contains a version of Emacs with support for a graphical user
@@ -38,14 +38,29 @@ Description: GNU Emacs editor (with Lucid GUI support)
  https://bugzilla.gnome.org/show_bug.cgi?id=85715 for more
  information.
 
+Package: @DEB_FLAVOR@-pgtk
+Architecture: any
+Depends: @DEB_FLAVOR@-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Provides: @DEB_FLAVOR@, emacsen, editor, info-browser, mail-reader, news-reader
+Suggests: @DEB_FLAVOR@-common-non-dfsg
+Conflicts: @DEB_FLAVOR_OTHER_NATIVE_COMP@-pgtk,
+  @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-nox, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-nox
+Description: GNU Emacs editor (with pure GTK GUI support)
+ GNU Emacs is the extensible self-documenting text editor.  This
+ package contains a version of Emacs with support for a graphical user
+ interface based on pure GTK.  We recommend that you use this only if
+ you are running a window system other than X that's supported by GDK,
+ such as Wayland and Broadway.
+
 Package: @DEB_FLAVOR@-nox
 Architecture: any
 Depends: @DEB_FLAVOR@-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides: @DEB_FLAVOR@, editor, emacsen, info-browser, mail-reader, news-reader
 Suggests: @DEB_FLAVOR@-common-non-dfsg
 Conflicts: @DEB_FLAVOR_OTHER_NATIVE_COMP@-nox,
-  @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
-Replaces: @DEB_FLAVOR@, @DEB_FLAVOR@-lucid
+  @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-pgtk, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-pgtk
 Description: GNU Emacs editor (without GUI support)
  GNU Emacs is the extensible self-documenting text editor.  This
  package contains a version of Emacs compiled without support for X,
@@ -57,8 +72,8 @@ Depends: @DEB_FLAVOR@-bin-common (= ${binary:Version}), ${shlibs:Depends}, ${mis
 Provides: editor, emacsen, info-browser, mail-reader, news-reader
 Suggests: @DEB_FLAVOR@-common-non-dfsg
 Conflicts: @DEB_FLAVOR_OTHER_NATIVE_COMP@,
-  @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-nox, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
-Replaces: @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-nox
+  @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-pgtk, @DEB_FLAVOR@-nox, @DEB_FLAVOR@-common (<< 2:20150222+emacs-pretest-24.0.05-15849-g3f006e1-1)
+Replaces: @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-pgtk, @DEB_FLAVOR@-nox
 Description: GNU Emacs editor (with GTK+ GUI support)
  GNU Emacs is the extensible self-documenting text editor.  This
  package contains a version of Emacs with a graphical user interface
@@ -72,7 +87,7 @@ Depends: @DEB_FLAVOR@-common (= ${source:Version}), ${shlibs:Depends}, ${misc:De
 Description: GNU Emacs editor's shared, architecture dependent files
  GNU Emacs is the extensible self-documenting text editor.
  This package contains the architecture dependent infrastructure
- that's shared by @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, and @DEB_FLAVOR@-nox.
+ that's shared by @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-pgtk, and @DEB_FLAVOR@-nox.
 
 # This depends on the emacs-el package. It is needed only for the native-comp
 # packages so tha they have something to compile. I leave the Depends even for
@@ -87,7 +102,7 @@ Conflicts: @DEB_FLAVOR_OTHER_NATIVE_COMP@-common,
 Description: GNU Emacs editor's shared, architecture independent infrastructure
  GNU Emacs is the extensible self-documenting text editor.
  This package contains the architecture independent infrastructure
- that's shared by @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, and @DEB_FLAVOR@-nox.
+ that's shared by @DEB_FLAVOR@, @DEB_FLAVOR@-lucid, @DEB_FLAVOR@-pgtk, and @DEB_FLAVOR@-nox.
 
 Package: @DEB_FLAVOR@-el
 Conflicts: @DEB_FLAVOR_OTHER_NATIVE_COMP@-el

--- a/debian/rules
+++ b/debian/rules
@@ -157,6 +157,12 @@ nonpersistent_autogen_install_files := \
   debian/$(flavor)-nox.menu \
   debian/$(flavor)-nox.postinst \
   debian/$(flavor)-nox.prerm \
+  debian/$(flavor)-pgtk.README.Debian \
+  debian/$(flavor)-pgtk.desktop \
+  debian/$(flavor)-pgtk.lintian-overrides \
+  debian/$(flavor)-pgtk.menu \
+  debian/$(flavor)-pgtk.postinst \
+  debian/$(flavor)-pgtk.prerm \
   debian/$(flavor)-lucid.README.Debian \
   debian/$(flavor)-lucid.desktop \
   debian/$(flavor)-lucid.lintian-overrides \
@@ -188,11 +194,13 @@ pkgdir_common := $(CURDIR)/debian/$(flavor)-common
 pkgdir_bin_common := $(CURDIR)/debian/$(flavor)-bin-common
 pkgdir_x := $(CURDIR)/debian/$(flavor)
 pkgdir_nox := $(CURDIR)/debian/$(flavor)-nox
+pkgdir_pgtk := $(CURDIR)/debian/$(flavor)-pgtk
 pkgdir_lucid := $(CURDIR)/debian/$(flavor)-lucid
 pkgdir_el := $(CURDIR)/debian/$(flavor)-el
 
 install_dir_x := $(CURDIR)/debian/install-x
 install_dir_nox := $(CURDIR)/debian/install-nox
+install_dir_pgtk := $(CURDIR)/debian/install-pgtk
 install_dir_lucid := $(CURDIR)/debian/install-lucid
 
 local_lpath := /etc/$(flavor):/etc/emacs
@@ -265,6 +273,9 @@ debian/$(flavor).%: pkg_name := $(flavor)
 debian/$(flavor)-nox.%: xsupport := "nox"
 debian/$(flavor)-nox.%: pkg_name := $(flavor)-nox
 
+debian/$(flavor)-pgtk.%: xsupport := "pgtk"
+debian/$(flavor)-pgtk.%: pkg_name := $(flavor)-pgtk
+
 debian/$(flavor)-lucid.%: xsupport := "lucid"
 debian/$(flavor)-lucid.%: pkg_name := $(flavor)-lucid
 
@@ -287,6 +298,9 @@ debian/$(flavor).%: debian/emacsVER.% debian/changelog
 	$(call deb_sub,$<,$@)
 
 debian/$(flavor)-nox.%: debian/emacsVER.% debian/changelog
+	$(call deb_sub,$<,$@)
+
+debian/$(flavor)-pgtk.%: debian/emacsVER.% debian/changelog
 	$(call deb_sub,$<,$@)
 
 debian/$(flavor)-lucid.%: debian/emacsVER.% debian/changelog
@@ -344,6 +358,10 @@ confflags_nox += --with-x=no
 confflags_nox += --without-gconf
 confflags_nox += --without-gsettings
 
+# pgtk configure flags
+confflags_pgtk := $(confflags) 
+confflags_pgtk += --with-pgtk
+
 # lucid configure flags
 confflags_lucid := $(confflags)
 confflags_lucid += --with-x=yes
@@ -376,11 +394,13 @@ override_dh_auto_configure: debian/setup-stamp
 	cp -a /usr/share/misc/config.sub .
 	$(call cfg_tree,debian/build-x,$(confflags_x))
 	$(call cfg_tree,debian/build-nox,$(confflags_nox))
+	$(call cfg_tree,debian/build-pgtk,$(confflags_pgtk))
 	$(call cfg_tree,debian/build-lucid,$(confflags_lucid))
 
 override_dh_auto_build: $(autogen_build_files)
 	$(call build_cmd,debian/build-x)
 	$(call build_cmd,debian/build-nox)
+	$(call build_cmd,debian/build-pgtk)
 	$(call build_cmd,debian/build-lucid)
 
 define install_common_binpkg_bits
@@ -406,11 +426,12 @@ endef
 
 override_dh_auto_install: $(autogen_install_files)
 	rm -rf \
-	  $(install_dir_x) $(install_dir_nox) $(install_dir_lucid) \
+	  $(install_dir_x) $(install_dir_nox) $(install_dir_pgtk) $(install_dir_lucid) \
 	  $(pkgdir_common)/* \
 	  $(pkgdir_bin_common)/* \
 	  $(pkgdir_x)/* \
 	  $(pkgdir_nox)/* \
+	  $(pkgdir_pgtk)/* \
 	  $(pkgdir_lucid)/* \
 	  $(pkgdir_el)/*
 
@@ -605,6 +626,25 @@ override_dh_auto_install: $(autogen_install_files)
         endif
 
         ##################################################
+        # emacsXY-pgtk
+        ifneq (,$(findstring $(flavor)-pgtk, $(shell dh_listpackages)))
+	  $(call emacs_inst,build-pgtk,$(install_dir_pgtk))
+	  $(call install_common_binpkg_bits,\
+	    $(install_dir_pgtk),$(pkgdir_pgtk),$(flavor)-pgtk,pgtk)
+	  install -d $(pkgdir_pgtk)/usr/lib/emacs/$(runtime_ver)/$(target)
+	  cp -a $(install_dir_pgtk)/usr/lib/emacs/$(runtime_ver)/$(target)/emacs*.pdmp $(pkgdir_pgtk)/usr/lib/emacs/$(runtime_ver)/$(target)
+	  $(if $(NO_NATIVE_COMP),,cp -a $(install_dir_pgtk)/usr/lib/emacs/$(runtime_ver)/native-lisp $(pkgdir_pgtk)/usr/lib/emacs/$(runtime_ver))
+
+          # install desktop entry
+	  install -d $(pkgdir_pgtk)/usr/share/applications
+	  install -m 0644 \
+	    debian/$(flavor)-pgtk.desktop \
+	    $(pkgdir_pgtk)/usr/share/applications/
+	  rm -rf $(install_dir_pgtk)
+
+        endif
+
+        ##################################################
         # emacsXY-lucid
         ifneq (,$(findstring $(flavor)-lucid, $(shell dh_listpackages)))
 	  $(call emacs_inst,build-lucid,$(install_dir_lucid))
@@ -637,6 +677,7 @@ override_dh_auto_install: $(autogen_install_files)
         # final cleanup
 	rm -rf $(install_dir_x)
 	rm -rf $(install_dir_nox)
+	rm -rf $(install_dir_pgtk)
 	rm -rf $(install_dir_lucid)
 
 override_dh_testdir:
@@ -653,11 +694,13 @@ override_dh_clean: $(persistent_autogen_files)
 	  configure \
 	  debian/*-stamp \
 	  debian/build-lucid \
+	  debian/build-pgtk \
 	  debian/build-nox \
 	  debian/build-x \
 	  debian/emacsVER-common.README.00 \
 	  debian/emacsVER-common.README.01 \
 	  debian/install-lucid \
+	  debian/install-pgtk \
 	  debian/install-nox \
 	  debian/install-x \
 	 	  src/stamp-h1 src/stamp-h.in


### PR DESCRIPTION
I've just tried -pgtk, though I normally prefer -lucid on xorg+twm.

Example to use Emacs in web browser (cf. man broadwayd):

```
$ broadwayd :5 &
$ firefox http://127.0.0.1:8085/ &
$ GDK_BACKEND=broadway BROADWAY_DISPLAY=:5 emacs-snapshot-pgtk &
```
